### PR TITLE
Fix string aliases, allow previous usernames

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -8,6 +8,7 @@ const aliases = {
 	evil: "EvilArtist",
 	ivy: "Spectaqual",
 	polarcub: "polarcub_art",
+	alect: "LambdaCrux"
 }
 
 const sortTypes = {


### PR DESCRIPTION
I just stumbled upon this domain and love the idea.

I fixed your string aliases, currently they return `[object Object]`, for example: [ugc.works/trus](https://ugc.works/trus)

Likewise, the Catalog API is not fond of previous usernames, so I added an HTTP request to automatically populate the latest username. This helps users like me who can't keep track of friends ever changing usernames, whilst keeping your aliases up to date.

I tested using a personal Cloudflare Worker, and couldn't spot any errors/breaking changes:
![image](https://user-images.githubusercontent.com/34300238/126056769-b360ca3e-6d61-4253-85b6-567373ddad59.png)

---

I also added an alias, `'alect'` for `Alectfenrir123` aka `LambdaCrux`.